### PR TITLE
Feature/support php8 phpunit bridge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
 
 matrix:
   include:
+    - php: 5.4
+      dist: trusty
     - php: 5.5
       dist: trusty
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
     - php: 5.4
       dist: trusty
     - php: 5.5
@@ -34,6 +32,6 @@ before_install:
 
 install: travis_retry composer update $COMPOSER_FLAGS --prefer-dist --no-interaction
 
-script: if [[ $COVERAGE = yes ]]; then vendor/bin/phpunit --verbose --coverage-clover=coverage.clover; else vendor/bin/phpunit --verbose; fi
+script: if [[ $COVERAGE = yes ]]; then vendor/bin/simple-phpunit --verbose --coverage-clover=coverage.clover; else vendor/bin/simple-phpunit --verbose; fi
 
 after_script: if [[ $COVERAGE = yes ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
 
 matrix:
   include:
-    - php: 5.4
-      dist: trusty
     - php: 5.5
       dist: trusty
     - php: 5.6
@@ -20,9 +18,7 @@ matrix:
         - ANALYSIS=yes
     - php: 7.4
     - php: hhvm-3.30
-    - php: nightly
-  allow_failures:
-    - php: nightly
+    - php: 8.0snapshot
   fast_finish: true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ cache:
 
 matrix:
   include:
-    - php: 5.4
-      dist: trusty
     - php: 5.5
       dist: trusty
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ matrix:
         - COVERAGE=yes
         - ANALYSIS=yes
     - php: 7.4
-    - php: hhvm-3.30
     - php: 8.0snapshot
   fast_finish: true
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ File Path Utility
 
 Latest release: [2.3.0](https://packagist.org/packages/webmozart/path-util#2.3.0)
 
-PHP >= 5.4
+PHP >= 5.5
 
 This package provides robust, cross-platform utility functions for normalizing,
 comparing and modifying file paths and URLs.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ File Path Utility
 
 Latest release: [2.3.0](https://packagist.org/packages/webmozart/path-util#2.3.0)
 
-PHP >= 5.3.3
+PHP >= 5.4
 
 This package provides robust, cross-platform utility functions for normalizing,
 comparing and modifying file paths and URLs.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,4 +31,4 @@ install:
 
 test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vendor\bin\phpunit.bat --verbose
+  - vendor\bin\simple-phpunit.bat --verbose

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
         }
     ],
     "require": {
-        "php": "^5.5|^7.0|^8.0",
+        "php": "^5.4|^7.0|^8.0",
         "webmozart/assert": "~1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.1",
+        "symfony/phpunit-bridge": "^4.1|^5.1",
         "sebastian/version": "^1.0.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "webmozart/assert": "~1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^5.1",
+        "symfony/phpunit-bridge": "^3.4|^5.1",
         "sebastian/version": "^1.0.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "webmozart/assert": "~1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.4|^5.1",
+        "symfony/phpunit-bridge": "^5.1",
         "sebastian/version": "^1.0.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0|^8.0",
+        "php": "^5.5|^7.0|^8.0",
         "webmozart/assert": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
         }
     ],
     "require": {
-        "php": "^5.4|^7.0|^8.0",
+        "php": "^5.5|^7.0|^8.0",
         "webmozart/assert": "~1.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^4.1|^5.1",
+        "symfony/phpunit-bridge": "^5.1",
         "sebastian/version": "^1.0.1"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,11 @@
         }
     ],
     "require": {
-        "php": "^5.3.3|^7.0|^8.0",
+        "php": "^5.4|^7.0|^8.0",
         "webmozart/assert": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6",
+        "symfony/phpunit-bridge": "^5.1",
         "sebastian/version": "^1.0.1"
     },
     "autoload": {

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -11,6 +11,8 @@
 
 namespace Webmozart\PathUtil\Tests;
 
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
 use Webmozart\PathUtil\Path;
 
 /**
@@ -19,11 +21,13 @@ use Webmozart\PathUtil\Path;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Thomas Schulz <mail@king2500.net>
  */
-class PathTest extends \PHPUnit_Framework_TestCase
+class PathTest extends TestCase
 {
+    use SetUpTearDownTrait;
+
     protected $storedEnv = array();
 
-    public function setUp()
+    protected function doSetUp()
     {
         $this->storedEnv['HOME'] = getenv('HOME');
         $this->storedEnv['HOMEDRIVE'] = getenv('HOMEDRIVE');
@@ -34,7 +38,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
         putenv('HOMEPATH=');
     }
 
-    public function tearDown()
+    protected function doTearDown()
     {
         putenv('HOME='.$this->storedEnv['HOME']);
         putenv('HOMEDRIVE='.$this->storedEnv['HOMEDRIVE']);
@@ -174,12 +178,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($canonicalized, Path::canonicalize($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testCanonicalizeFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::canonicalize(array());
     }
 
@@ -246,12 +248,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($directory, Path::getDirectory($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testGetDirectoryFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::getDirectory(array());
     }
 
@@ -276,12 +276,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($filename, Path::getFilename($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testGetFilenameFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::getFilename(array());
     }
 
@@ -318,21 +316,17 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($filename, Path::getFilenameWithoutExtension($path, $extension));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testGetFilenameWithoutExtensionFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::getFilenameWithoutExtension(array(), '.css');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The extension must be a string or null. Got: array
-     */
     public function testGetFilenameWithoutExtensionFailsIfInvalidExtension()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The extension must be a string or null. Got: array');
         Path::getFilenameWithoutExtension('/style.css', array());
     }
 
@@ -368,12 +362,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($extension, Path::getExtension($path, $forceLowerCase));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testGetExtensionFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::getExtension(array());
     }
 
@@ -428,21 +420,17 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($hasExtension, Path::hasExtension($path, $extension, $ignoreCase));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testHasExtensionFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::hasExtension(array());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The extensions must be strings. Got: stdClass
-     */
     public function testHasExtensionFailsIfInvalidExtension()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The extensions must be strings. Got: stdClass');
         Path::hasExtension('/style.css', (object) array());
     }
 
@@ -474,21 +462,17 @@ class PathTest extends \PHPUnit_Framework_TestCase
         ++$call;
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testChangeExtensionFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::changeExtension(array(), '.sass');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The extension must be a string. Got: array
-     */
     public function testChangeExtensionFailsIfInvalidExtension()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The extension must be a string. Got: array');
         Path::changeExtension('/style.css', array());
     }
 
@@ -529,12 +513,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($isAbsolute, Path::isAbsolute($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testIsAbsoluteFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::isAbsolute(array());
     }
 
@@ -546,12 +528,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(!$isAbsolute, Path::isRelative($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testIsRelativeFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::isRelative(array());
     }
 
@@ -591,12 +571,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($root, Path::getRoot($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testGetRootFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::getRoot(array());
     }
 
@@ -696,48 +674,38 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($absolutePath, Path::makeAbsolute($relativePath, $basePath));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testMakeAbsoluteFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::makeAbsolute(array(), '/webmozart/puli');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path must be a non-empty string. Got: array
-     */
     public function testMakeAbsoluteFailsIfInvalidBasePath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path must be a non-empty string. Got: array');
         Path::makeAbsolute('css/style.css', array());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path "webmozart/puli" is not an absolute path.
-     */
     public function testMakeAbsoluteFailsIfBasePathNotAbsolute()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path "webmozart/puli" is not an absolute path.');
         Path::makeAbsolute('css/style.css', 'webmozart/puli');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path must be a non-empty string. Got: ""
-     */
     public function testMakeAbsoluteFailsIfBasePathEmpty()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path must be a non-empty string. Got: ""');
         Path::makeAbsolute('css/style.css', '');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path must be a non-empty string. Got: NULL
-     */
     public function testMakeAbsoluteFailsIfBasePathNull()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path must be a non-empty string. Got: NULL');
         Path::makeAbsolute('css/style.css', null);
     }
 
@@ -882,57 +850,47 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($relativePath, Path::makeRelative($absolutePath, $basePath));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testMakeRelativeFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::makeRelative(array(), '/webmozart/puli');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path must be a string. Got: array
-     */
     public function testMakeRelativeFailsIfInvalidBasePath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path must be a string. Got: array');
         Path::makeRelative('/webmozart/puli/css/style.css', array());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.
-     */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathNotAbsolute()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "webmozart/puli". You should provide an absolute base path instead.');
         Path::makeRelative('/webmozart/puli/css/style.css', 'webmozart/puli');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.
-     */
     public function testMakeRelativeFailsIfAbsolutePathAndBasePathEmpty()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The absolute path "/webmozart/puli/css/style.css" cannot be made relative to the relative path "". You should provide an absolute base path instead.');
         Path::makeRelative('/webmozart/puli/css/style.css', '');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path must be a string. Got: NULL
-     */
     public function testMakeRelativeFailsIfBasePathNull()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path must be a string. Got: NULL');
         Path::makeRelative('/webmozart/puli/css/style.css', null);
     }
 
     /**
      * @dataProvider provideAbsolutePathsWithDifferentRoots
-     * @expectedException \InvalidArgumentException
      */
     public function testMakeRelativeFailsIfDifferentRoot($absolutePath, $basePath)
     {
+        $this->expectException('\InvalidArgumentException');
         Path::makeRelative($absolutePath, $basePath);
     }
 
@@ -955,12 +913,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($isLocal, Path::isLocal($path));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testIsLocalFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::isLocal(array());
     }
 
@@ -1084,12 +1040,10 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($basePath, Path::getLongestCommonBasePath($paths));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The paths must be strings. Got: array
-     */
     public function testGetLongestCommonBasePathFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The paths must be strings. Got: array');
         Path::getLongestCommonBasePath(array(array()));
     }
 
@@ -1184,21 +1138,17 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, Path::isBasePath($path, $ofPath));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base path must be a string. Got: array
-     */
     public function testIsBasePathFailsIfInvalidBasePath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base path must be a string. Got: array');
         Path::isBasePath(array(), '/base/path');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The path must be a string. Got: array
-     */
     public function testIsBasePathFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The path must be a string. Got: array');
         Path::isBasePath('/base/path', array());
     }
 
@@ -1291,21 +1241,17 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/path/to/test/subdir', Path::join('/path', 'to', '/test', 'subdir/'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The paths must be strings. Got: array
-     */
     public function testJoinFailsIfInvalidPath()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The paths must be strings. Got: array');
         Path::join('/path', array());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Your environment or operation system isn't supported
-     */
     public function testGetHomeDirectoryFailsIfNotSupportedOperationSystem()
     {
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('Your environment or operation system isn\'t supported');
         putenv('HOME=');
 
         Path::getHomeDirectory();
@@ -1330,11 +1276,9 @@ class PathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('C:/Foo/Bar/test', Path::normalize('C:\\Foo\\Bar/test'));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testNormalizeFailsIfNoString()
     {
+        $this->expectException('\InvalidArgumentException');
         Path::normalize(true);
     }
 }

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -11,6 +11,7 @@
 
 namespace Webmozart\PathUtil\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Webmozart\PathUtil\Url;
 
 /**
@@ -19,7 +20,7 @@ use Webmozart\PathUtil\Url;
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Claudio Zizza <claudio@budgegeria.de>
  */
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends TestCase
 {
     /**
      * @dataProvider provideMakeRelativeTests
@@ -60,63 +61,62 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The URL must be a string. Got: array
      * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfInvalidUrl()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The URL must be a string. Got: array');
         Url::makeRelative(array(), 'http://example.com/webmozart/puli');
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base URL must be a string. Got: array
      * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfInvalidBaseUrl()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base URL must be a string. Got: array');
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', array());
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "webmozart/puli" is not an absolute Url.
      * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfBaseUrlNoUrl()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('"webmozart/puli" is not an absolute Url.');
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', 'webmozart/puli');
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "" is not an absolute Url.
      * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfBaseUrlEmpty()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('"" is not an absolute Url.');
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', '');
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The base URL must be a string. Got: NULL
      * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfBaseUrlNull()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The base URL must be a string. Got: NULL');
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', null);
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The URL "http://example.com" cannot be made relative to "http://example2.com" since
-     *                           their host names are different.
      * @covers Webmozart\PathUtil\Url
      */
     public function testMakeRelativeFailsIfDifferentDomains()
     {
+        $this->expectException('\InvalidArgumentException');
+        $this->expectExceptionMessage('The URL "http://example.com" cannot be made relative to "http://example2.com" since their host names are different.');
         Url::makeRelative('http://example.com/webmozart/puli/css/style.css', 'http://example2.com/webmozart/puli');
     }
 


### PR DESCRIPTION
Hi @Th3Mouk,

I found a solution to the setUp/tearDown void return type issue mentioned in https://github.com/webmozart/path-util/pull/31#issuecomment-702608729. I was able to get a php 8 compatibility, while also being able to support php 5.5 and 5.6, but at a cost of something else:

* `symfony/phpunit-bridge` might allow us to make `path-util` compatible to php 5, but I had to remove `5.3` as the void return type problem is solved by a trait and traits in php are only support in `>=5.4`
* 5.4 had to be removed, as `symfony/phpunit-bridge` `3.*|4.*` does not support that new trait that solves the void issue. That has been introduced in version 5, but that is only compatible to php `>=5.5.9`
* I had to remove `hhvm-3.30` from the build config as `phpunit-bridge` did not work with it, but I don't think it's a loss, since hhvm no longer supported php in a later version anyway

What do you think? I think it's better than changing the php version constraint to `=>7.1` and drop php 5 support.